### PR TITLE
Added CLI commands for each action listed in the README.md

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -1,3 +1,4 @@
+var cmds = require('./clicmds.js');
 var command = process.argv[2]
 var CryptoJS = require("crypto-js")
 const { randomBytes } = require('crypto')
@@ -18,25 +19,48 @@ switch (command) {
             priv: bs58.encode(priv)
         }
         break;
+
     case 'sign':
-        // usage: npm run cli sign <privKey> <username> <raw_transaction>
-        // will return a new transaction with a hash and a signature
-        var privKey = process.argv[3]
-        var sender = process.argv[4]
-        var tx = process.argv[5]
-        tx = JSON.parse(tx)
-        tx.sender = sender
-        // add timestamp to seed the hash (avoid transactions reuse)
-        tx.ts = new Date().getTime()
-        // hash the transaction
-        tx.hash = CryptoJS.SHA256(JSON.stringify(tx)).toString()
-        // sign the transaction
-        var signature = secp256k1.sign(new Buffer(tx.hash, "hex"), bs58.decode(privKey))
-        tx.signature = bs58.encode(signature.signature)
-        
-        break;
+		// private key, sender, transaction to send
+		cmds.sign(process.argv[3], process.argv[4], process.argv[5])
+		break;
+
+    case 'approveNode':
+		// node user
+		cmds.approveNode(process.argv[5])
+		break;
+
+	case 'disapproveNode':
+		// node user
+		cmds.disapproveNode(process.argv[5])
+		break;
+	
+	case 'transfer':
+		// reciever, amount
+		cmds.transfer(process.argv[5], process.argv[6])
+		break;
+
+	case 'post':
+		// uri, conent json
+		cmds.post(process.argv[5], process.argv[6])
+		break;
+
+	case 'comment':
+		// uri, parent author, parent permalink, content json
+		cmds.post(process.argv[5], process.argv[6], process.argv[7], process.argv[8])
+		break;
+
+	case 'vote':
+		// uri, author, weight
+		cmds.post(process.argv[5], process.argv[6], process.argv[7])
+		break;
+
+	case 'profile':
+		// uri, author, weight
+		cmds.post(process.argv[5], process.argv[6], process.argv[7])
+		break;
 
     default:
         break;
 }
-console.log(JSON.stringify(tx))
+

--- a/src/clicmds.js
+++ b/src/clicmds.js
@@ -1,0 +1,74 @@
+var privKey = process.argv[3]
+var sender = process.argv[4]
+var CryptoJS = require("crypto-js")
+const { randomBytes } = require('crypto')
+const secp256k1 = require('secp256k1')
+const bs58 = require('bs58')
+
+let sign = (privKey, sender, tx) => {
+	// will return a new transaction with a hash and a signature
+	tx = JSON.parse(tx)
+	tx.sender = sender
+	// add timestamp to seed the hash (avoid transactions reuse)
+	tx.ts = new Date().getTime()
+	// hash the transaction
+	tx.hash = CryptoJS.SHA256(JSON.stringify(tx)).toString()
+	// sign the transaction
+	var signature = secp256k1.sign(new Buffer(tx.hash, "hex"), bs58.decode(privKey))
+	tx.signature = bs58.encode(signature.signature)
+	return console.log(JSON.stringify(tx))
+}
+
+let cmds = {
+	approveNode: (nodeName) => {
+		// npm cli.js approveNode <privKey> <username> <node username>
+		var tx = '{"type":1,"data":{"target":"'+ nodeName +'"}}'
+		sign(privKey, sender, tx)
+	}, 
+	
+	disapproveNode: (nodeName) => {
+		// npm cli.js disapproveNode <privKey> <username> <node username>
+		var tx = '{"type":2,"data":{"target":"'+ nodeName +'"}}'
+		sign(privKey, sender, tx)
+	},
+
+	transfer: (reciever, amount) => {
+		// npm cli.js disapproveNode <privKey> <username> <reciver> <amount>
+		var tx = '{"type":3,"data":{"receiver":"'+
+			reciever+'", "amount":'+
+			parseFloat(amount)+'}}'
+		sign(privKey, sender, tx)
+	},
+
+	post: (uri, content) => {
+		// npm cli.js disapproveNode <privKey> <username> <uri> <json content>
+		var tx = '{"type":4,"data":{"link":"'+
+			uri+'","json":'+content+'}}'
+		sign(privKey, sender, tx)
+	},
+
+	comment: (uri, pa, pp, content) => {
+		// npm cli.js disapproveNode <privKey> <username> \
+		// <uri> <parent author> <parent permalink> <json content>
+		var tx = '{"type":4,"data":{"link":"'+
+			uri+'", "pa":"'+
+			pa+'", "pp":"'+
+			pp+'","json":'+content+'}}'
+		sign(privKey, sender, tx)
+	},
+
+	vote: (uri, author, weight) => {
+		var tx = '{"type":5,"data":{"link":"'+
+			uri+'", "author":"'+
+			author+'", "vt": '+
+			parseFloat(weight)+'}}'
+		sign(privKey, sender, tx)
+	},
+
+	profile: (content) => {
+		var tx = '{"type":6,"data":{"json":{"profile":{"'+content+'"}}}}'
+		sign(privKey, sender, tx)
+	}
+}
+
+module.exports = cmds


### PR DESCRIPTION
`clicmd.js` holds all the functions called by `cli.js` including approving/disapproving nodes, creating a post, commenting, voting, transferring tokens, and updating the user profile. 

This allows the CLI user ignore the formatting for items such as the type number. The formatting is hard-coded and all the user needs to worry about are the string or floats that change with each transaction.